### PR TITLE
Add some rudimentary support for time zones

### DIFF
--- a/src/WebFrontend/Components/CalendarMonthlyViewComponent.razor
+++ b/src/WebFrontend/Components/CalendarMonthlyViewComponent.razor
@@ -2,7 +2,7 @@
 
 @code {
     [Inject]
-    BookingService _bookingService { get; set; }
+    BookingService _bookingService { get; set; }    
 
     [Parameter]
     public Guid resourceGuid { get; set; }
@@ -85,7 +85,8 @@
     @while(dayCounter <= DateTime.DaysInMonth(_startDate.Year, _startDate.Month))
     {
         for(int x = 0; x < 7; x++) {
-            bool isToday = ((DateTime.Now.Year == _startDate.Year) && (DateTime.Now.Month == _startDate.Month) && (DateTime.Now.Day == dayCounter));
+            
+            bool isToday = ((Today.Year == _startDate.Year) && (Today.Month == _startDate.Month) && (Today.Day == dayCounter));
             
             @if ((dayCounter > 0) && (dayCounter <= DateTime.DaysInMonth(_startDate.Year, _startDate.Month))) 
             {            

--- a/src/WebFrontend/Pages/ViewResource.razor
+++ b/src/WebFrontend/Pages/ViewResource.razor
@@ -3,11 +3,16 @@
 @page "/Resources/{resourceguid}/{year:int}/{month:int}"
 @page "/Resources/{resourceguid}/{year:int}/{month:int}/{day:int}"
 @using LSSD.Bookings
+@using Microsoft.Extensions.Configuration
 
 @code {
 
     [Inject]
     ResourceService _resourceService { get; set; }
+
+    [Inject]
+    IConfiguration _configuration { get; set; }
+    
 
     [Parameter]
     public string resourceguid { get; set; }
@@ -24,6 +29,8 @@
 
     Resource selectedResource = null;   
 
+    DateTime today_date = DateTime.Now;
+
     protected override void OnInitialized()
     {
         if (year == 0) {
@@ -37,7 +44,12 @@
         if (resourceguid != null) 
         {
             selectedResource = _resourceService.Get(resourceguid);
-        }            
+        }   
+
+        if(!string.IsNullOrEmpty(_configuration["Settings:TimeZone"])) {
+            TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById(_configuration["Settings:TimeZone"]);
+            today_date = TimeZoneInfo.ConvertTimeFromUtc(DateTime.Now.ToUniversalTime(), timeZone);
+        }         
     } 
 }
 
@@ -54,7 +66,10 @@
             <p>
                 Click a day to create a booking.
             </p>
-            <WebFrontend.Components.CalendarMonthlyViewComponent resourceGuid="@selectedResource.Id" Year="@year" Month="@month" Today="@(DateTime.Now)" />
+            
+            <WebFrontend.Components.CalendarMonthlyViewComponent resourceGuid="@selectedResource.Id" Year="@year" Month="@month" Today="@(today_date)" />
+
+            @(today_date.ToString("dddd, MMMM dd, yyyy HH:mm:ss"))
         }
     </Authorized>
 </AuthorizeView>

--- a/src/WebFrontend/Pages/ViewResource.razor
+++ b/src/WebFrontend/Pages/ViewResource.razor
@@ -68,8 +68,6 @@
             </p>
             
             <WebFrontend.Components.CalendarMonthlyViewComponent resourceGuid="@selectedResource.Id" Year="@year" Month="@month" Today="@(today_date)" />
-
-            @(today_date.ToString("dddd, MMMM dd, yyyy HH:mm:ss"))
         }
     </Authorized>
 </AuthorizeView>

--- a/src/WebFrontend/Services/BookingService.cs
+++ b/src/WebFrontend/Services/BookingService.cs
@@ -7,34 +7,47 @@ using System.Threading.Tasks;
 using System.Security.Cryptography.X509Certificates;
 using LSSD.Bookings;
 using System.Linq.Expressions;
+using Microsoft.Extensions.Configuration;
 
 namespace WebFrontend
 {
     public class BookingService
     {
         private readonly IRepository<SingleBooking> _repository;
+        private readonly IConfiguration configuration;
 
 
-        public BookingService(IRepository<SingleBooking> Repository)
+        public BookingService(IRepository<SingleBooking> Repository, IConfiguration Configuration)
         {
             this._repository = Repository;
+            configuration = Configuration;
         }
         public void Insert(SingleBooking obj) 
         {
+            // Adjust time zones to UTC
+            // Adjust booking date (if applicable)
+            // Adjust booking hour and minute
+
             _repository.Insert(obj);
         }
         public void Update(SingleBooking obj) 
         {
+            // Adjust time zones to UTC
+
             _repository.Update(obj);
         }
 
         public SingleBooking Get(string id)
         {
+            // Adjust time zones to UTC
+
             return _repository.GetById(id);
         }
 
         public IList<SingleBooking> Find(Expression<Func<SingleBooking, bool>> predicate)
         {
+            // Adjust time zones to UTC
+
             return _repository.Find(predicate);
         }
         

--- a/src/WebFrontend/Services/BookingService.cs
+++ b/src/WebFrontend/Services/BookingService.cs
@@ -14,43 +14,120 @@ namespace WebFrontend
     public class BookingService
     {
         private readonly IRepository<SingleBooking> _repository;
-        private readonly IConfiguration configuration;
+        private readonly IConfiguration _configuration;
+
+        private TimeZoneInfo AdjustedTimeZone;
+        private bool AdjustTimeZone = false;
 
 
         public BookingService(IRepository<SingleBooking> Repository, IConfiguration Configuration)
         {
             this._repository = Repository;
-            configuration = Configuration;
-        }
-        public void Insert(SingleBooking obj) 
-        {
-            // Adjust time zones to UTC
-            // Adjust booking date (if applicable)
-            // Adjust booking hour and minute
+            _configuration = Configuration;
 
-            _repository.Insert(obj);
+            if(!string.IsNullOrEmpty(_configuration["Settings:TimeZone"])) {
+            try {
+                TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById(_configuration["Settings:TimeZone"]);
+                AdjustedTimeZone = timeZone;
+                AdjustTimeZone = true;
+            }
+            catch {}
         }
-        public void Update(SingleBooking obj) 
+        }
+        public void Insert(SingleBooking obj)
         {
-            // Adjust time zones to UTC
+            SingleBooking newObj = obj;
 
-            _repository.Update(obj);
+            if(AdjustTimeZone) {
+                newObj = AdjustTimeZoneToUTC(obj, AdjustedTimeZone);
+            }
+
+            _repository.Insert(newObj);
+        }
+        public void Update(SingleBooking obj)
+        {
+            SingleBooking newObj = obj;
+
+            if(AdjustTimeZone) {
+                newObj = AdjustTimeZoneToUTC(obj, AdjustedTimeZone);
+            }
+
+            _repository.Update(newObj);
         }
 
         public SingleBooking Get(string id)
         {
             // Adjust time zones to UTC
+            SingleBooking UTCBooking =  _repository.GetById(id);
 
-            return _repository.GetById(id);
+            if (AdjustTimeZone)  {
+                UTCBooking = AdjustTimeZoneFromUTC(UTCBooking, AdjustedTimeZone);
+            }
+
+            return UTCBooking;
         }
 
         public IList<SingleBooking> Find(Expression<Func<SingleBooking, bool>> predicate)
         {
             // Adjust time zones to UTC
+            IList<SingleBooking> UTCResults = _repository.Find(predicate);
 
-            return _repository.Find(predicate);
+            if (AdjustTimeZone) {
+                IList<SingleBooking> _convertedResults = new List<SingleBooking>();
+                foreach(SingleBooking booking in UTCResults) {
+                    _convertedResults.Add(AdjustTimeZoneFromUTC(booking, AdjustedTimeZone));
+                }
+                return _convertedResults;
+            } else {
+                return UTCResults;
+            }
         }
-        
+
+        private static SingleBooking AdjustTimeZoneToUTC(SingleBooking booking, TimeZoneInfo TimeZone) {
+            // Adjust time zones to UTC
+
+            // Create a date in the user's timezone
+            DateTime nonUTCStartDate = new DateTime(
+                booking.BookingDate.Year,
+                booking.BookingDate.Month,
+                booking.BookingDate.Day,
+                booking.StartHourUTC,
+                booking.StartMinuteUTC,
+                0);
+
+            // Adjust that date to the server timezone and extract parts
+            DateTime UTCStartDateWithTime = TimeZoneInfo.ConvertTimeToUtc(nonUTCStartDate, TimeZone);
+
+            booking.BookingDate = UTCStartDateWithTime.Date;
+            booking.StartHourUTC = UTCStartDateWithTime.Hour;
+            booking.StartMinuteUTC = UTCStartDateWithTime.Minute;
+
+            return booking;
+        }
+
+        private static SingleBooking AdjustTimeZoneFromUTC(SingleBooking booking, TimeZoneInfo TimeZone) {
+            // Adjust time zones to UTC
+
+            // Create a date in the user's timezone
+            DateTime nonUTCStartDate = new DateTime(
+                booking.BookingDate.Year,
+                booking.BookingDate.Month,
+                booking.BookingDate.Day,
+                booking.StartHourUTC,
+                booking.StartMinuteUTC,
+                0);
+
+            // Adjust that date to the server timezone and extract parts
+            DateTime UTCStartDateWithTime = TimeZoneInfo.ConvertTimeFromUtc(nonUTCStartDate, TimeZone);
+
+            booking.BookingDate = UTCStartDateWithTime.Date;
+            booking.StartHourUTC = UTCStartDateWithTime.Hour;
+            booking.StartMinuteUTC = UTCStartDateWithTime.Minute;
+
+            return booking;
+        }
+
+
 
     }
 }


### PR DESCRIPTION
Because the API and FrontEnd will be running in containers, they will be in UTC, so the data sent to the database will also be in UTC.

This should display all dates in the frontend in a given timezone, if one is provided via configuration (which we'll do as an environment variable into the container in our deployment).

It's not going to work if we need to support a single frontend with multiple timezones, but for now that is not a concern.